### PR TITLE
Update it.js

### DIFF
--- a/src/locale/it.js
+++ b/src/locale/it.js
@@ -23,7 +23,7 @@ const locale = {
     s: 'qualche secondo',
     m: 'un minuto',
     mm: '%d minuti',
-    h: 'un\' ora',
+    h: 'un\'ora',
     hh: '%d ore',
     d: 'un giorno',
     dd: '%d giorni',


### PR DESCRIPTION
In italian language, there is no space between "un\'ora". We write "un\'ora" and not "un\' ora".